### PR TITLE
(docs) Add payload column to snapshot table in creation SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ CREATE TABLE {your_snapshot_table_name} (
     sequence_nr BIGINT NOT NULL,
     created_at BIGINT NOT NULL,
     manifest VARCHAR(500) NOT NULL,
+    payload BYTEA NOT NULL,
     snapshot BYTEA NOT NULL,
     serializer_id INTEGER NULL,
     CONSTRAINT {your_snapshot_table_name}_pk PRIMARY KEY (persistence_id, sequence_nr)


### PR DESCRIPTION
Resolves #45.

## Problem
As discovered in #45, when following the `README` sql setup directions, they do not include a mention of a `payload` column in the snapshot table, resulting in errors.

## Solution
I think it was one line left out of the `README` , so I am operating under the assumption that the fix is to put the line into the `README` doc. This PR adds that line.

It may be that additional follow-up is needed to add a note to the other migration docs, but I'm not sure that will be necessary.