### PR TITLE
Avoid expensive SQL call

### DIFF
--- a/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
@@ -93,6 +93,8 @@ namespace Akka.Persistence.PostgreSql.Journal
         protected override DbCommand CreateCommand(DbConnection connection) => ((NpgsqlConnection)connection).CreateCommand();
         protected override string CreateEventsJournalSql { get; }
         protected override string CreateMetaTableSql { get; }
+        // Fetching all distinct persistence IDs takes a long time and is not always necessary
+        protected override string AllPersistenceIdsSql => $@"";
 
         protected override void WriteEvent(DbCommand command, IPersistentRepresentation e, IImmutableSet<string> tags)
         {


### PR DESCRIPTION
 - we are having issues fetching all distinct persistence IDs in a PostgresDB with 2 million journal events
 - unless someone can tell me otherwise, I don't see the need to fetch all these events (on our TEST environment it can take 20 minutes sometimes)